### PR TITLE
Support specifying extra emacs pkgs from nixpkgs

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,8 +342,8 @@ Add `(package! foo)` to `packages.el`.
 Do not wrap emacsWithDoom in emacsWithPackages. See HACKING.md for why this will
 not work.
 
-If this is not sufficient, file an issue. I can add a hook to add more packages
-from Nix: I just don't want to add that hook unless someone has a use for it.
+The home-manager option `extraPackages` is available to add extra Emacs packages from nixpkgs to Doom Emacs.
+If this is not sufficient, please file an issue. 
 
 ### How do I add packages not in Emacs overlay?
 

--- a/README.md
+++ b/README.md
@@ -321,6 +321,10 @@ This issue is currently confirmed to affect golang.
 
 See issue [#7](https://github.com/marienz/nix-doom-emacs-unstraightened/issues/7) for a more detailed explanation.
 
+Considering that Doom Emacs will likely use the Emacs 29+ built-in tree-sitter at some point at least as an opt-in 
+(see related [Doom Emacs issue](https://github.com/doomemacs/doomemacs/issues/7623)) 
+this particular issue for Unstraightened is unlikely to get solved.
+
 As a workaround the following is possible:
 - Temporarily disable Doom Emacs from handling tree-sitter in `init.el`.
 - Define your nix Emacs package to be compiled with native tree-sitter support.

--- a/README.md
+++ b/README.md
@@ -314,6 +314,25 @@ Unstraightened uses `--init-directory`, as the doctor recommends.
 
 Safe to ignore, for the same reason as the previous warning.
 
+### tree-sitter error on initialization with `file-error "Opening output file" "Read-only file system"`
+The ABI loaded for some grammars from nixpkgs is too new (14) compared to what vanilla Doom Emacs receives (13).
+This results in tree-sitter and some particular grammars to be incompatible.
+This issue is currently confirmed to affect golang.
+
+See issue [#7](https://github.com/marienz/nix-doom-emacs-unstraightened/issues/7) for a more detailed explanation.
+
+As a workaround the following is possible:
+- Temporarily disable Doom Emacs from handling tree-sitter in `init.el`.
+- Define your nix Emacs package to be compiled with native tree-sitter support.
+- Use package [treesit-auto](https://github.com/renzmann/treesit-auto) (e.g. it to `packages.el`) 
+to gracefully include activation of tree-sitter specific modes of a programming language, 
+depending on if a particular grammer is installed or not.
+- Include Emacs package `treesit-grammars.with-all-grammars` from nixpkgs,
+e.g. use the home-manager option `extraPackages` like so:
+`extraPackages = epkgs: [ epkgs.treesit-grammars.with-all-grammars ];`.
+
+As a result tree-sitter (built-in to Emacs) will be compatible with the current ABI for grammars included in nixpkgs.
+
 ## Frequently Anticipated Questions
 
 ### How do I add more packages?

--- a/README.md
+++ b/README.md
@@ -172,6 +172,11 @@ The home-manager module supports the same options, as well as:
 - `provideEmacs`: disable this to only provide a `doom-emacs` binary, not an
   `emacs` binary (that is: it switches from `emacsWithDoom` to `doomEmacs`). Use
   this if you want to install vanilla Emacs in parallel.
+  
+- `extraPackages`: Specify extra Emacs packages from nixpkgs to be available to Doom Emacs. 
+Defaults to this function `epkgs: [ ]` (no extra packages).
+For example to include Emacs package `treesit-grammars.with-all-grammars`:
+`extraPackages = epkgs: [ epkgs.treesit-grammars.with-all-grammars ];`.
 
 ## Comparison to "normal" Doom Emacs
 

--- a/checks.nix
+++ b/checks.nix
@@ -85,4 +85,6 @@ in {
 
   # Various tests of module combinations.
   unpinned-org = doomTest "external-org" { app = [ [ "rss" "+org" ] ]; } { };
+
+  extraPackages = doomTest "extraPackages" { config = [ "default" ]; } { extraPackages = epkgs: [ epkgs.vterm ]; };
 }

--- a/checks.nix
+++ b/checks.nix
@@ -67,6 +67,10 @@ in {
   minimalEmacs = (makeDoomPackages (common // {
     doomDir = minimalDoomDir;
   })).emacsWithDoom;
+  minimalExtraPackages = mkDoom {
+    doomDir = minimalDoomDir;
+    extraPackages = epkgs: [ epkgs.vterm epkgs.treesit-grammars.with-all-grammars ];
+  };
   allModules = mkDoom { doomDir = allModsDoomDir; };
   allModulesAndFlags = mkDoom { doomDir = allFlagsDoomDir; };
   example = mkDoom { doomDir = ./doomdir; };

--- a/default.nix
+++ b/default.nix
@@ -332,8 +332,8 @@ let
 
   # Step 3: Build an emacsWithPackages, pulling all packages from step 1 from
   # the set from step 2.
-    emacsWithPackages = doomEmacsPackages.emacsWithPackages
-      (epkgs: (map (p: epkgs.${p}) (builtins.attrNames doomPackageSet)) ++ (extraPackages epkgs));
+  emacsWithPackages = doomEmacsPackages.emacsWithPackages
+    (epkgs: (map (p: epkgs.${p}) (builtins.attrNames doomPackageSet)) ++ (extraPackages epkgs));
 
   # Step 4: build a DOOMDIR, Doom profile and profile loader using Emacs from
   # step 3 and packages.el from step 1.

--- a/default.nix
+++ b/default.nix
@@ -38,6 +38,8 @@
   noProfileHack ? false,
   /* Use fetchTree instead of fetchGit for package fetches. */
   experimentalFetchTree ? false,
+  /* Extra emacs packages from nixpkgs */
+  extraPackages ? epkgs: [ ],
 
   callPackages,
   git,
@@ -330,8 +332,8 @@ let
 
   # Step 3: Build an emacsWithPackages, pulling all packages from step 1 from
   # the set from step 2.
-  emacsWithPackages = doomEmacsPackages.emacsWithPackages
-    (epkgs: (map (p: epkgs.${p}) (builtins.attrNames doomPackageSet)));
+    emacsWithPackages = doomEmacsPackages.emacsWithPackages
+      (epkgs: (map (p: epkgs.${p}) (builtins.attrNames doomPackageSet)) ++ (extraPackages epkgs));
 
   # Step 4: build a DOOMDIR, Doom profile and profile loader using Emacs from
   # step 3 and packages.el from step 1.

--- a/home-manager.nix
+++ b/home-manager.nix
@@ -100,12 +100,25 @@ in {
         type = hm.types.selectorFunction;
         defaultText = "epkgs: [ ]";
         example = literalExpression
-          "epkgs: [ epkgs.vterm epkgs.treesit-grammars.with-all-grammars ]";
+          "epkgs: [ epkgs.treesit-grammars.with-all-grammars ]";
         description = ''
-          Extra packages available to Doom Emacs.
-          To let nix handle a doom dependency '(package! ...)' we can leverage the ':built-in t' argument
-          Consider the following example for 'vterm' in the doom config packages.el:
-          (package! vterm :built-in t)
+          Extra Emacs packages from nixpkgs available to Doom Emacs,
+          unless that packages is handled by Doom Emacs.
+
+          If Doom Emacs specifies a package,
+          then that specific package and version will be exactly as Doom specifies even if it's
+          included in 'extraPackages'.
+
+          To use 'extraPackages' to override a specific package otherwise specified by Doom Emacs,
+          it is required that the Doom Emacs config use the following arguments for the package:
+          '(package! ... :built-in t)'
+          This allows nix to be used to apply patches to an Emacs package.
+
+          Some Emacs packages from nixpkgs have additional side-effects specific to nix,
+          consider the Emacs Package 'treesit-grammars.with-all-grammars'.
+          It downloads all treesitter grammars defined in nixpkgs at build time and makes them
+          available on path for Emacs at runtime.
+          Doom cannot specify that package using the '(package! ...)' syntax.
         '';
       };
     };

--- a/home-manager.nix
+++ b/home-manager.nix
@@ -17,7 +17,7 @@
 
 let
   cfg = config.programs.doom-emacs;
-  inherit (lib) literalExpression mkEnableOption mkIf mkMerge mkOption types;
+  inherit (lib) literalExpression mkEnableOption mkIf mkMerge mkOption types hm;
 in {
   options = {
     programs.doom-emacs = {
@@ -94,13 +94,27 @@ in {
         readOnly = true;
         description = "The final doom-emacs package";
       };
+
+      extraPackages = mkOption {
+        default = self: [ ];
+        type = hm.types.selectorFunction;
+        defaultText = "epkgs: [ ]";
+        example = literalExpression
+          "epkgs: [ epkgs.vterm epkgs.treesit-grammars.with-all-grammars ]";
+        description = ''
+          Extra packages available to Doom Emacs.
+          To let nix handle a doom dependency '(package! ...)' we can leverage the ':built-in t' argument
+          Consider the following example for 'vterm' in the doom config packages.el:
+          (package! vterm :built-in t)
+        '';
+      };
     };
   };
 
   config = mkIf cfg.enable (mkMerge [
     (let
       doomPackages = doomFromPackages pkgs {
-        inherit (cfg) emacs doomDir doomLocalDir profileName noProfileHack;
+        inherit (cfg) emacs doomDir doomLocalDir profileName noProfileHack extraPackages;
       };
     in
       {

--- a/tests.el
+++ b/tests.el
@@ -49,4 +49,7 @@
     (write-region result nil out nil nil nil 'mustbenew))
   (kill-emacs))
 
+(defun test-extraPackages ()
+  (require 'vterm))
+
 (add-hook 'doom-after-init-hook 'test-doom)


### PR DESCRIPTION
- [x] Have signed the CLA
- [x] Technical changes related to issue #7 included.
- [x] README updated describing work-around (and sort of legitamizing the existence of `extraPackages`)

The following checks succeed:
- `nix build .\#checks.x86_64-linux.minimalExtraPackages` 
  - (NEW) should likely be tweaked with a call to elisp `list-packages` to verify that `vterm` is external. What do you think?
-  `nix build .\#checks.x86_64-linux.minimal` 

I have also bumped my local doom-emacs using my config and the changes in this fork and can anecdotally attest that it works as expected for my (yet undocumented) use-case.

*EDIT: Updating checkbox status.