### PR TITLE
Pass `extraBinPackages` through to `doomFromPackages`

### DIFF
--- a/home-manager.nix
+++ b/home-manager.nix
@@ -158,7 +158,7 @@ in {
     (let
       doomPackages = doomFromPackages pkgs {
         inherit (cfg) emacs doomDir doomLocalDir profileName noProfileHack extraPackages
-          experimentalFetchTree;
+          extraBinPackages experimentalFetchTree;
       };
     in
       {


### PR DESCRIPTION
Seems like the home manager module forgets to pass along `extraBinPackages` when building doom with `doomFromPackages.

This commit just adds `extraBinPackages` to be passed through.