### PR TITLE
WIP: enable LSP_USE_PLISTS

### DIFF
--- a/build-helpers/build-doom-emacs.sh
+++ b/build-helpers/build-doom-emacs.sh
@@ -20,6 +20,11 @@ commonArgs=(
     --set-default DOOMLOCALDIR "$doomLocalDir"
     --set DOOMDIR $doomProfile/doomdir
 )
+if [[ -n $lspUsePlists ]]; then
+    commonArgs+=(
+        --set LSP_USE_PLISTS 1
+    )
+fi
 
 makeWrapper $emacsWithPackages/bin/emacs $out/bin/doom-emacs \
     "${commonArgs[@]}" \

--- a/home-manager.nix
+++ b/home-manager.nix
@@ -154,6 +154,18 @@ in
         '';
       };
 
+      lspUsePlists = mkOption {
+        default = true;
+        example = false;
+        type = types.bool;
+        description = ''
+          Build lsp-mode (and packages using it) with LSP_USE_PLISTS set.
+
+          This may improve performance (see
+          https://emacs-lsp.github.io/lsp-mode/page/performance/#use-plists-for-deserialization).
+        '';
+      };
+
       # Home Manager-specific options.
       provideEmacs = mkOption {
         type = types.bool;
@@ -199,6 +211,7 @@ in
             extraBinPackages
             tangleArgs
             emacsPackageOverrides
+            lspUsePlists
             ;
         };
       in


### PR DESCRIPTION
This contains some unrelated changes that need to be split back out.

It seems to work, but could do with more testing, especially to confirm the "only apply it to lsp-mode-related packages" hack holds up in practice.

For #83