### PR TITLE
fix extrabinpackages

### DIFF
--- a/build-helpers/build-doom-emacs.sh
+++ b/build-helpers/build-doom-emacs.sh
@@ -19,6 +19,7 @@ commonArgs=(
     --set DOOMPROFILE "$profileName"
     --set-default DOOMLOCALDIR "$doomLocalDir"
     --set DOOMDIR $doomProfile/doomdir
+    --suffix PATH ":" "$extraBinPackagesPath"
 )
 if [[ -n $lspUsePlists ]]; then
     commonArgs+=(

--- a/default.nix
+++ b/default.nix
@@ -480,6 +480,8 @@ let
     name = "doom-emacs";
     buildCommandPath = ./build-helpers/build-doom-emacs.sh;
 
+    extraBinPackagesPath = lib.makeBinPath extraBinPackages;
+
     # emacsWithPackages also accessed externally (for pushing to Cachix).
     inherit
       doomProfile


### PR DESCRIPTION
AFAICT, packages passed to `extraBinPackages` are passed directly down to `emacs.withPackages`. This doesn't seem to make it so emacs can find packages when e.g. creating subprocesses.

This PR adds an additional `makeWrapper` flag to inject the passed `extraBinPackages` into `$PATH` directly in the wrapper.