### PR TITLE
Make Emacs.app work on macOS

### DIFF
--- a/build-helpers/build-emacs-with-doom.sh
+++ b/build-helpers/build-emacs-with-doom.sh
@@ -31,4 +31,5 @@ if [ -d "$emacs/Applications" ]; then
     cp -R "$emacs/Applications" "$out/Applications"
     chmod -R u+w "$out/Applications"
     ln -sf "$out/bin/emacs" "$out/Applications/Emacs.app/Contents/MacOS/Emacs"
+    rm -f $out/Applications/Emacs.app/Contents/native-lisp
 fi


### PR DESCRIPTION
This is a fix for https://github.com/marienz/nix-doom-emacs-unstraightened/issues/90

The fix is to delete the relative link that is generated in the app bundle.