### PR TITLE
Fix unreadable doom-profile symlink permissions on macOS

### DIFF
--- a/build-helpers/build-doom-profile.sh
+++ b/build-helpers/build-doom-profile.sh
@@ -41,3 +41,19 @@ if grep -q -F "$TMPDIR/" -r $out; then
     echo "Doom profile contains a forbidden reference to $TMPDIR/"
     exit 1
 fi
+
+# Nix normalizes the permissions of regular files in $out to a world-readable
+# mode after the build, but (deliberately) leaves symlinks alone, since Linux
+# does not support chmod'ing (or even meaningfully storing the mode of) a
+# symlink. Any symlink created with a restrictive umask (e.g. by Emacs' own
+# `with-file-modes' in doom-profile-generate) therefore ships into the store
+# exactly as created. That is harmless on Linux (permission bits on symlinks
+# are not checked there), but not on macOS, where such a symlink becomes
+# unreadable to anything other than its owner/group, breaking tools like
+# `cachix push' that read the whole store path. Fail the build if that happens
+# again instead of shipping a broken store path silently.
+if find $out -type l ! -perm -444 -print | grep -q .; then
+    echo "Doom profile contains symlinks that are not world-readable:"
+    find $out -type l ! -perm -444 -ls
+    exit 1
+fi

--- a/build-helpers/build-doom-profile.sh
+++ b/build-helpers/build-doom-profile.sh
@@ -52,8 +52,8 @@ fi
 # unreadable to anything other than its owner/group, breaking tools like
 # `cachix push' that read the whole store path. Fail the build if that happens
 # again instead of shipping a broken store path silently.
-if find $out -type l ! -perm -444 -print | grep -q .; then
+if find "$out" -type l ! -perm -004 -print | grep -q .; then
     echo "Doom profile contains symlinks that are not world-readable:"
-    find $out -type l ! -perm -444 -ls
+    find "$out" -type l ! -perm -004 -ls
     exit 1
 fi

--- a/build-helpers/build-doom-profile.sh
+++ b/build-helpers/build-doom-profile.sh
@@ -47,11 +47,19 @@ fi
 # does not support chmod'ing (or even meaningfully storing the mode of) a
 # symlink. Any symlink created with a restrictive umask (e.g. by Emacs' own
 # `with-file-modes' in doom-profile-generate) therefore ships into the store
-# exactly as created. That is harmless on Linux (permission bits on symlinks
-# are not checked there), but not on macOS, where such a symlink becomes
-# unreadable to anything other than its owner/group, breaking tools like
-# `cachix push' that read the whole store path. Fail the build if that happens
-# again instead of shipping a broken store path silently.
+# exactly as created.
+#
+# That is harmless on Linux (permission bits on symlinks are not checked
+# there). It is also harmless in the common case on macOS, because merely
+# *following* a symlink (e.g. opening the file it points to) never checks its
+# permission bits either, on any OS. It only matters on macOS when something
+# calls readlink(2) to retrieve the link's literal target string instead of
+# following it, which is exactly what building a NAR to push to a binary
+# cache requires: `cachix push' (and any other NAR-producing tool) fails to
+# read such a symlink when run as anyone other than its owner or group, e.g.
+# the invoking CI user reading a path built by the nix-daemon build user.
+# Fail the build if that happens again instead of shipping a broken store
+# path silently.
 if find "$out" -type l ! -perm -004 -print | grep -q .; then
     echo "Doom profile contains symlinks that are not world-readable:"
     find "$out" -type l ! -perm -004 -ls

--- a/build-helpers/build-profile
+++ b/build-helpers/build-profile
@@ -21,7 +21,14 @@
 
 (defun generate-unstraightened-init-load (_profile)
   "Load unstraightened init.el."
-  (make-symbolic-link init-file "00-unstraightened-init.load.el"))
+  ;; `doom-profile-generate' wraps profile generation in `with-file-modes'
+  ;; #o750, so a symlink created here would otherwise end up group/other
+  ;; inaccessible. That is harmless on Linux (permission bits on symlinks
+  ;; are not checked), but not on macOS, where it breaks anything reading the
+  ;; Nix store as a different user, such as `cachix push'. Override back to a
+  ;; normal, world-readable mode for this symlink specifically.
+  (with-file-modes #o755
+    (make-symbolic-link init-file "00-unstraightened-init.load.el")))
 
 (add-to-list 'doom-profile-generate-functions
              #'generate-unstraightened-init-load)

--- a/build-helpers/build-profile
+++ b/build-helpers/build-profile
@@ -22,11 +22,12 @@
 (defun generate-unstraightened-init-load (_profile)
   "Load unstraightened init.el."
   ;; `doom-profile-generate' wraps profile generation in `with-file-modes'
-  ;; #o750, so a symlink created here would otherwise end up group/other
-  ;; inaccessible. That is harmless on Linux (permission bits on symlinks
-  ;; are not checked), but not on macOS, where it breaks anything reading the
-  ;; Nix store as a different user, such as `cachix push'. Override back to a
-  ;; normal, world-readable mode for this symlink specifically.
+  ;; #o750, so a symlink created here would otherwise end up inaccessible to
+  ;; anyone other than its owner or group. That is harmless on Linux
+  ;; (permission bits on symlinks are not checked), but not on macOS, where it
+  ;; breaks anything reading the Nix store as a different user, such as
+  ;; `cachix push'. Override back to a normal, world-readable mode for this
+  ;; symlink specifically.
   (with-file-modes #o755
     (make-symbolic-link init-file "00-unstraightened-init.load.el")))
 


### PR DESCRIPTION
## Summary
- `doom-profile-generate` (Doom core) wraps profile generation in `(with-file-modes #o750 ...)`, so the `00-unstraightened-init.load.el` symlink created by `generate-unstraightened-init-load` in `build-helpers/build-profile` inherited that restrictive mode (`lrwxr-x---`) instead of the world-readable mode every other file in `$out` gets.
- Nix's build sandbox normalizes regular files to a world-readable mode after the build, but deliberately leaves symlinks untouched (Linux has no `lchmod`), so this restrictive permission shipped straight into the store as-is.
- This is harmless on Linux (symlink permission bits aren't enforced there), but on macOS it makes the symlink unreadable to anyone but its owner/group — which broke `cachix push` (`readSymbolicLink: permission denied`) reading the store path as a different user on a `macos-latest` GitHub Actions runner. Any other tool reading the Nix store as a non-owner on macOS (`nix copy`, etc.) would hit the same issue.

## Fix
- `build-helpers/build-profile`: wrap the `make-symbolic-link` call in a nested `(with-file-modes #o755 ...)`, overriding Doom's `#o750` for just that call. (Verified empirically that nested `with-file-modes` correctly overrides the outer one for its dynamic extent before relying on it.)
- `build-helpers/build-doom-profile.sh`: add a build-time assertion (`find $out -type l ! -perm -444`) that fails the derivation loudly if any symlink ships non-world-readable, so a similar regression is caught by CI instead of silently shipping a broken store path. This runs on every build of `doomProfile`, which `check.yml`/`cachix.yml` already exercise on both `ubuntu-latest` and `macos-latest`.

I deliberately avoided a `find ... -exec chmod -h 755 {} +`-style fix: GNU coreutils' `chmod -h` relies on `lchmod()`, which doesn't exist on Linux, so that would fail (and abort the build, since these scripts run under `set -eu`) on every Linux build.

Audited the rest of `build-helpers/` and Doom core's `doom-profile-generate-functions` for other `make-symbolic-link`/file-creation calls with the same latent issue — didn't find any; everything else either writes regular files (auto-normalized by Nix) or creates symlinks via shell `ln -s` outside Doom's restrictive `with-file-modes` scope.

## Test plan
- [x] Reproduced the bug by building `doomProfile` locally on macOS (aarch64-darwin) and confirming `00-unstraightened-init.load.el` came out `lrwxr-x---` while every other file in the output was world-readable.
- [x] Applied the fix and rebuilt: the symlink is now `lrwxr-xr-x`, matching the rest of the derivation's output.
- [x] Temporarily reverted the `with-file-modes` fix and rebuilt to confirm the new build-time assertion catches the regression and fails the build with a clear message.
- [x] Restored the fix and built `checks.example` and `checks.allModules` end-to-end (through `doomProfile` → `doomEmacs`) with no permission-check failures or other regressions.